### PR TITLE
ci(infra): diagnose release-ui-core unstaged-changes failure (refs #213)

### DIFF
--- a/.github/workflows/release-ui-core.yml
+++ b/.github/workflows/release-ui-core.yml
@@ -81,6 +81,12 @@ jobs:
 
           FINAL_TAG="ui-core/v$VERSION"
 
+          # Diagnostic: capture working tree state right after checkout+install
+          # (before any intentional write) to see if pnpm install left drift.
+          echo "::group::git status right after install"
+          git status --porcelain
+          echo "::endgroup::"
+
           # Only commit and push if version changed
           if [ "$VERSION" != "$CURRENT_VERSION" ]; then
             echo "Version bumped from $CURRENT_VERSION to $VERSION"
@@ -92,14 +98,19 @@ jobs:
             jq --arg v "$VERSION" '.version = $v' package.json > tmp.json && mv tmp.json package.json
             git add VERSION packages/ui/package.json package.json
             git commit -m "chore(release): bump to $VERSION [skip ci]"
-            
+
+            echo "::group::git status after commit, before rebase"
+            git status --porcelain
+            git diff --stat
+            echo "::endgroup::"
+
             # Fetch and rebase to avoid non-fast-forward on rerun
             git fetch origin master
-            git rebase origin/master
-            
+            git -c rebase.autoStash=true rebase origin/master
+
             # Push changes to master
             git push origin master
-            
+
             echo "bumped=true" >> $GITHUB_OUTPUT
           else
             echo "No version bump needed"
@@ -115,8 +126,14 @@ jobs:
               jq --arg v "$VERSION" '.version = $v' package.json > tmp.json && mv tmp.json package.json
               git add packages/ui/package.json package.json
               git commit -m "chore(release): sync package.json to $VERSION [skip ci]"
+
+              echo "::group::git status after sync commit, before rebase"
+              git status --porcelain
+              git diff --stat
+              echo "::endgroup::"
+
               git fetch origin master
-              git rebase origin/master
+              git -c rebase.autoStash=true rebase origin/master
               git push origin master
             fi
             echo "bumped=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- `release-ui-core` が PR #213 マージ後も `error: cannot rebase: You have unstaged changes.` で失敗継続（run [24599669879](https://github.com/vemikrs/mirelplatform/actions/runs/24599669879)）。
- 該当 run の install ログは `Lockfile is up to date, resolution step is skipped` で lockfile drift は否定。PR #213 の root-cause fix (vemikrs/yuihub#165 相当) は効いているが、**別要因で working tree が汚れている**。現行ログには unstaged ファイル名が出ず原因特定不可。
- 本 PR は「診断」と「即時復旧」を両立させる最小変更。

## Changes
1. `.github/workflows/release-ui-core.yml` の "Check Version and Auto Bump" step に `git status --porcelain` + `git diff --stat` を 3 地点で追加:
   - `pnpm install --frozen-lockfile` 直後（初期状態確認）
   - bump commit 後 / rebase 直前
   - sync commit 後 / rebase 直前
2. 両 `git rebase origin/master` を `git -c rebase.autoStash=true rebase origin/master` に変更。unstaged を自動 stash→pop させて CI 緑化。

## Why this, not a direct root-cause fix
- 失敗ログに unstaged ファイル名が出ていない → 根本原因が特定できない段階でパッチを当てると yuihub #163 と同じ「症状を隠す修正」になる。
- 診断ログを出した上で `--autostash` で通過させれば、次 run のログで原因ファイルが判明し、次 PR で恒久対応（例: 該当ファイルを事前 commit、該当設定の明示化、等）が可能。

## Test plan
- [ ] merge 後に `release-ui-core` を手動 `workflow_dispatch`
- [ ] `git status right after install` グループで drift の有無を確認
- [ ] `git status after ... commit, before rebase` グループで unstaged ファイル名を特定
- [ ] `--autostash` により rebase→push が通り `ui-core/v3.2.64` がリリースされることを確認
- [ ] 原因ファイルに対する恒久対応 PR を次に起票

🤖 Generated with [Claude Code](https://claude.com/claude-code)