### PR TITLE
ci(infra): dump pnpm-lock.yaml drift diff for root-cause fix (refs #214)

### DIFF
--- a/.github/workflows/release-ui-core.yml
+++ b/.github/workflows/release-ui-core.yml
@@ -83,8 +83,14 @@ jobs:
 
           # Diagnostic: capture working tree state right after checkout+install
           # (before any intentional write) to see if pnpm install left drift.
+          # run 24600445487 で " M pnpm-lock.yaml" を確認済み。実際の diff 中身を
+          # 取得して恒久対応（master に追記）の判断材料にする。
           echo "::group::git status right after install"
           git status --porcelain
+          echo "::endgroup::"
+
+          echo "::group::git diff pnpm-lock.yaml (full, right after install)"
+          git --no-pager diff pnpm-lock.yaml
           echo "::endgroup::"
 
           # Only commit and push if version changed


### PR DESCRIPTION
## Summary
- PR #214 の診断で `pnpm install --frozen-lockfile` が \"Lockfile is up to date\" と表示しつつ実際には `pnpm-lock.yaml` を書き換えている事実を確認（run [24600445487](https://github.com/vemikrs/mirelplatform/actions/runs/24600445487)）。
- `--autostash` で rebase は通るが drift 本体は毎 run 発生しており、yuihub #163 の safety-net と同型の症状隠蔽構造になっている。
- 本 PR は install 直後の `git diff pnpm-lock.yaml` 全文を CI ログに出力して、恒久対応（pnpm-lock.yaml に drift 分を master へ取り込む）の判断材料を得ることが目的。

## Changes
- `.github/workflows/release-ui-core.yml` の \"Check Version and Auto Bump\" step に `git --no-pager diff pnpm-lock.yaml` 全文ダンプを追加（`::group::` で折り畳み）。
- PR #213 で commit した `packageManagerDependencies` ブロックでは drift の一部しか潰せなかった。残存分を本 PR の次 run で特定する。

## Test plan
- [ ] merge 後に `release-ui-core` を手動 `workflow_dispatch`
- [ ] \"git diff pnpm-lock.yaml (full, right after install)\" グループに出力された diff を確認
- [ ] 次 PR で該当 diff を master の `pnpm-lock.yaml` に取り込み、drift ゼロを担保
- [ ] 最終 PR で `--autostash` safety-net を撤去

🤖 Generated with [Claude Code](https://claude.com/claude-code)