### PR TITLE
fix(frontend)+ci: axios型エラー解消とPRビルド検証の追加

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,44 +22,8 @@ env:
   TZ: Asia/Tokyo
 
 jobs:
-  typecheck:
-    name: TypeScript Typecheck
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: TypeScript typecheck (frontend-v3)
-        run: pnpm --filter frontend-v3 exec tsc --noEmit
-
-      - name: TypeScript typecheck (@mirel/ui)
-        run: pnpm --filter @mirel/ui exec tsc --noEmit
+  # frontend-v3 / @mirel/ui の TypeScript 型チェックは pr-build-verify.yml と ci-ui-package.yml に集約。
+  # ここでは E2E に固有の検証のみを保持する。
 
   validate-setup:
     name: Validate E2E Test Setup
@@ -121,7 +85,7 @@ jobs:
     name: End-to-End Tests
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [validate-setup, typecheck]
+    needs: [validate-setup]
     strategy:
       fail-fast: false
       matrix:
@@ -396,7 +360,7 @@ jobs:
     name: Accessibility Audit
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [validate-setup, typecheck]
+    needs: [validate-setup]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/pr-build-verify.yml
+++ b/.github/workflows/pr-build-verify.yml
@@ -1,0 +1,90 @@
+name: PR Build Verify
+
+# PR 時点で master push と同等のビルド検証を行うことで、
+# build-frontend-artifact.yml / docker-build.yml がマージ後に初めて落ちる事故を防ぐ。
+# 副作用（git tag push, ghcr push, master commit）は一切持たない。
+
+on:
+    pull_request:
+        branches: [master]
+        paths:
+            - "apps/frontend-v3/**"
+            - "packages/ui/**"
+            - "backend/**"
+            - "Dockerfile"
+            - "Dockerfile.backend"
+            - "package.json"
+            - "pnpm-lock.yaml"
+            - "pnpm-workspace.yaml"
+            - "VERSION"
+            - ".github/workflows/pr-build-verify.yml"
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+concurrency:
+    group: pr-build-verify-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    frontend-build:
+        name: Frontend Build (tsc + vite)
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
+            - name: Install pnpm
+              uses: pnpm/action-setup@v6
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: "24"
+                  cache: "pnpm"
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Build frontend-v3
+              run: pnpm --filter frontend-v3 build
+
+    docker-build-verify:
+        name: Docker Build Verify (${{ matrix.type }})
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - type: all-in-one
+                      dockerfile: ./Dockerfile
+                    - type: backend-only
+                      dockerfile: ./Dockerfile.backend
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
+            - name: Read VERSION file
+              id: version
+              run: echo "version=$(cat VERSION)" >> $GITHUB_OUTPUT
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v4
+
+            - name: Build Docker image (no push)
+              uses: docker/build-push-action@v7
+              with:
+                  context: .
+                  file: ${{ matrix.dockerfile }}
+                  push: false
+                  load: false
+                  cache-from: type=gha,scope=${{ matrix.type }}
+                  cache-to: type=gha,mode=max,scope=${{ matrix.type }}
+                  platforms: linux/amd64
+                  build-args: |
+                      NODE_VERSION=22
+                      NVM_VERSION=0.39.7
+                      APP_VERSION=${{ steps.version.outputs.version }}

--- a/apps/frontend-v3/src/features/promarker/hooks/useGenerate.ts
+++ b/apps/frontend-v3/src/features/promarker/hooks/useGenerate.ts
@@ -70,13 +70,18 @@ export const useGenerate = () => {
           );
 
           // Extract filename from Content-Disposition header
-          const contentDisposition = response.headers['content-disposition'];
-          const downloadFileName = contentDisposition 
-            ? decodeURIComponent(contentDisposition.split('=')[1])
+          const contentDispositionRaw = response.headers['content-disposition'];
+          const contentDisposition =
+            typeof contentDispositionRaw === 'string' ? contentDispositionRaw : '';
+          const filenamePart = contentDisposition.split('=')[1];
+          const downloadFileName = filenamePart
+            ? decodeURIComponent(filenamePart)
             : fileName;
 
           // Create blob and trigger download
-          const blob = new Blob([response.data], { type: response.headers['content-type'] });
+          const contentTypeRaw = response.headers['content-type'];
+          const contentType = typeof contentTypeRaw === 'string' ? contentTypeRaw : undefined;
+          const blob = new Blob([response.data], { type: contentType });
           const url = (window.URL || (window as any).webkitURL).createObjectURL(blob);
           
           const link = document.createElement('a');


### PR DESCRIPTION
## Summary

- master push 後の `Build Frontend Artifact` / `Docker Build and Push` が axios `^1.15.2` 由来の型エラー（`AxiosHeaderValue` に `null` が含まれるようになった件）でこけた事象の修正と再発防止。
- 修正は2コミット構成:
  1. `fix(frontend)`: [useGenerate.ts](apps/frontend-v3/src/features/promarker/hooks/useGenerate.ts) で `content-type` / `content-disposition` を `string` にナローイング。
  2. `ci(infra)`: 副作用なしの新規 [pr-build-verify.yml](.github/workflows/pr-build-verify.yml) を追加し、PR 時点で `tsc -b && vite build` と Docker build (`push: false`) を実行。あわせて [e2e-tests.yml](.github/workflows/e2e-tests.yml) の重複 typecheck job を削除し集約。

## なぜ PR では通ったのか

PR #236 (dependabot) のチェックには `Build Frontend Artifact` も `Docker Build and Push` も含まれていなかった（両者とも `push: master` トリガーのみ）。e2e-tests.yml の `tsc --noEmit` は走っていたが、`tsc -b` + `vite build` を含む完全ビルドではすり抜けた。本PRで PR 時点に `tsc -b && vite build` を必ず通す経路を追加する。

## 設計方針

- 既存 `build-frontend-artifact.yml`（バージョンbump+tag push）と `docker-build.yml`（ghcr push: true）はマージ後の副作用付きで動作するため**触らない**。
- 新規 `pr-build-verify.yml` は副作用ゼロ:
  - frontend-build: `pnpm --filter frontend-v3 build`
  - docker-build-verify: matrix (all-in-one / backend-only) を `push: false`、ghcr 認証なし
- `e2e-tests.yml` の typecheck job は `pr-build-verify.yml` と `ci-ui-package.yml` に集約して削除。frontend-v3 の tsconfig は @mirel/ui を project reference していないのでカバレッジ後退なし（@mirel/ui は ci-ui-package.yml が paths でカバー）。

## Test plan

- [ ] このPR上で `PR Build Verify / Frontend Build (tsc + vite)` が成功すること
- [ ] このPR上で `PR Build Verify / Docker Build Verify (all-in-one)` が成功すること
- [ ] このPR上で `PR Build Verify / Docker Build Verify (backend-only)` が成功すること
- [ ] `E2E Tests` が引き続き grenn（typecheck job 削除後の needs 整合性確認）
- [ ] マージ後 `Build Frontend Artifact` と `Docker Build and Push` が green になり master の赤が解消されること

## Follow-up（本PR範囲外）

- branch protection の required check に `PR Build Verify / *` を追加して、すり抜け再発を構造的に塞ぐ運用判断（リポジトリ管理者の作業）。