### PR TITLE
ci(release): publish-first ordering and concurrency guard for ui-core

### DIFF
--- a/.github/workflows/release-ui-core.yml
+++ b/.github/workflows/release-ui-core.yml
@@ -16,6 +16,12 @@ permissions:
   contents: write
   id-token: write
 
+# 同一ワークフローの並走を抑止。master への bump push と他ワークフローの
+# rebase 競合（2026-05-11 障害）を防ぐ。
+concurrency:
+  group: release-ui-core-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     # pushイベント、またはマージされたPRの場合のみ実行
@@ -148,6 +154,25 @@ jobs:
           echo "tag_name=$FINAL_TAG" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: Build
+        run: |
+          cd packages/ui
+          pnpm build
+
+      # 順序: Build → Publish → Tag。
+      # publish 失敗時に tag を残さないことで「tag だけ存在し npm に穴」状態を防ぐ
+      # (2026-05-11 障害の構造的対策)。
+      - name: Publish to npm
+        run: |
+          cd packages/ui
+          VERSION="${{ steps.check_version.outputs.version }}"
+          # Check if version already exists on npm (idempotent)
+          if npm view @mireljs/ui-core@$VERSION version 2>/dev/null; then
+            echo "Version $VERSION already published, skipping..."
+          else
+            npm publish --access public --provenance
+          fi
+
       - name: Create Tag
         run: |
           TAG_NAME="${{ steps.check_version.outputs.tag_name }}"
@@ -158,22 +183,6 @@ jobs:
           else
             git tag $TAG_NAME
             git push origin $TAG_NAME
-          fi
-
-      - name: Build
-        run: |
-          cd packages/ui
-          pnpm build
-
-      - name: Publish to npm
-        run: |
-          cd packages/ui
-          VERSION="${{ steps.check_version.outputs.version }}"
-          # Check if version already exists on npm (idempotent)
-          if npm view @mireljs/ui-core@$VERSION version 2>/dev/null; then
-            echo "Version $VERSION already published, skipping..."
-          else
-            npm publish --access public --provenance
           fi
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary

2026-05-11 のリリース障害（OIDC publish 失敗時に tag だけ残置 → rerun で rebase conflict）に対する構造的対策。

## 問題の経緯

PR #272 (vemiorg 移管) merge 後、`Release @mireljs/ui-core` が連続失敗した:

1. **初回 run**: VERSION 3.2.73 → bump 3.2.74 → **tag push 完了** → `npm publish` で `ENEEDAUTH`（OIDC token を npm が拒否、TP 設定が旧 owner 向けだったため）→ workflow fail
2. **rerun**: VERSION=3.2.74、tag は既存 → bump 3.2.75 → 並行 push との **rebase conflict** で fail
3. 結果として **tag `ui-core/v3.2.74` が残置、npm には 3.2.74 が未公開**の不整合状態が発生

最終的にローカルから手動 publish で復旧（3.2.74 は provenance なし）。詳細経緯は本 PR の元になった調査スレッド参照。

## 変更内容

### 1. 順序入替: Build → Publish → Tag → GitHub Release

旧: `Create Tag → Build → Publish to npm → GH Release`  
新: `Build → Publish to npm → Create Tag → GH Release`

publish 失敗時に tag を残さないことで、「tag だけ存在し npm に穴」状態を構造的に排除。

### 2. concurrency guard 追加

\`\`\`yaml
concurrency:
  group: release-ui-core-\${{ github.ref }}
  cancel-in-progress: false
\`\`\`

同一ワークフローの並走を抑止し、bump commit と他ワークフローの rebase 競合を防ぐ。`cancel-in-progress: false` により実行中のリリースを途中で殺さない（途中キャンセルは npm 公開と tag 状態が不整合になりうる）。

## 冪等性

いずれの step も rerun 安全に設計されている:

| ステップ | ガード |
|---|---|
| Check Version | `git ls-remote --tags origin` で既存 tag 検出して bump スキップ |
| Publish to npm | `npm view @mireljs/ui-core@\$VERSION version` で既存検出 |
| Create Tag | `git ls-remote --tags origin` で既存検出 |
| GitHub Release | `softprops/action-gh-release@v3` がそもそも upsert 動作 |

## Test plan

- [ ] このPR merge 後、自動 trigger される release-ui-core run で:
  - [ ] OIDC publish が成功（vemiorg 側 Trusted Publisher の実走確認も兼ねる）
  - [ ] tag が正しく付与される
  - [ ] GitHub Release が作成される
  - [ ] 3.2.75 以降は `dist.attestations.provenance` が復活していること（`npm view @mireljs/ui-core@3.2.75 --json` で確認）