### PR TITLE
ci(docker): retry ghcr.io login and use repository_owner as username

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,12 +51,34 @@ jobs:
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v4
 
+            # docker/login-action の代わりにシェルでログインしてリトライ。
+            # 2026-05-11 に ghcr.io への login で Client.Timeout が複数回発生
+            # （プラットフォーム既知問題: github/community/discussions/182234 /
+            # githubstatus.com/incidents/vkr22005hg0x）。
+            # username は github.actor ではなく repository_owner にして
+            # 移管後も新 org が一貫して使われるようにする。
             - name: Log in to GitHub Container Registry
-              uses: docker/login-action@v4
-              with:
-                  registry: ${{ env.REGISTRY }}
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
+              shell: bash
+              env:
+                  GHCR_REGISTRY: ${{ env.REGISTRY }}
+                  GHCR_USER: ${{ github.repository_owner }}
+                  GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  MAX_ATTEMPTS=3
+                  for attempt in $(seq 1 $MAX_ATTEMPTS); do
+                      echo "[attempt $attempt/$MAX_ATTEMPTS] Logging into $GHCR_REGISTRY as $GHCR_USER..."
+                      if echo "$GHCR_TOKEN" | docker login "$GHCR_REGISTRY" -u "$GHCR_USER" --password-stdin; then
+                          echo "Login succeeded on attempt $attempt"
+                          exit 0
+                      fi
+                      if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+                          BACKOFF=$((attempt * 10))
+                          echo "Login failed, waiting ${BACKOFF}s before retry..."
+                          sleep "$BACKOFF"
+                      fi
+                  done
+                  echo "All $MAX_ATTEMPTS login attempts failed" >&2
+                  exit 1
 
             - name: Extract metadata (tags, labels)
               id: meta
@@ -117,12 +139,34 @@ jobs:
             packages: read
 
         steps:
+            # docker/login-action の代わりにシェルでログインしてリトライ。
+            # 2026-05-11 に ghcr.io への login で Client.Timeout が複数回発生
+            # （プラットフォーム既知問題: github/community/discussions/182234 /
+            # githubstatus.com/incidents/vkr22005hg0x）。
+            # username は github.actor ではなく repository_owner にして
+            # 移管後も新 org が一貫して使われるようにする。
             - name: Log in to GitHub Container Registry
-              uses: docker/login-action@v4
-              with:
-                  registry: ${{ env.REGISTRY }}
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
+              shell: bash
+              env:
+                  GHCR_REGISTRY: ${{ env.REGISTRY }}
+                  GHCR_USER: ${{ github.repository_owner }}
+                  GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  MAX_ATTEMPTS=3
+                  for attempt in $(seq 1 $MAX_ATTEMPTS); do
+                      echo "[attempt $attempt/$MAX_ATTEMPTS] Logging into $GHCR_REGISTRY as $GHCR_USER..."
+                      if echo "$GHCR_TOKEN" | docker login "$GHCR_REGISTRY" -u "$GHCR_USER" --password-stdin; then
+                          echo "Login succeeded on attempt $attempt"
+                          exit 0
+                      fi
+                      if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+                          BACKOFF=$((attempt * 10))
+                          echo "Login failed, waiting ${BACKOFF}s before retry..."
+                          sleep "$BACKOFF"
+                      fi
+                  done
+                  echo "All $MAX_ATTEMPTS login attempts failed" >&2
+                  exit 1
 
             - name: Pull and inspect image
               run: |
@@ -182,12 +226,34 @@ jobs:
             packages: read
 
         steps:
+            # docker/login-action の代わりにシェルでログインしてリトライ。
+            # 2026-05-11 に ghcr.io への login で Client.Timeout が複数回発生
+            # （プラットフォーム既知問題: github/community/discussions/182234 /
+            # githubstatus.com/incidents/vkr22005hg0x）。
+            # username は github.actor ではなく repository_owner にして
+            # 移管後も新 org が一貫して使われるようにする。
             - name: Log in to GitHub Container Registry
-              uses: docker/login-action@v4
-              with:
-                  registry: ${{ env.REGISTRY }}
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
+              shell: bash
+              env:
+                  GHCR_REGISTRY: ${{ env.REGISTRY }}
+                  GHCR_USER: ${{ github.repository_owner }}
+                  GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  MAX_ATTEMPTS=3
+                  for attempt in $(seq 1 $MAX_ATTEMPTS); do
+                      echo "[attempt $attempt/$MAX_ATTEMPTS] Logging into $GHCR_REGISTRY as $GHCR_USER..."
+                      if echo "$GHCR_TOKEN" | docker login "$GHCR_REGISTRY" -u "$GHCR_USER" --password-stdin; then
+                          echo "Login succeeded on attempt $attempt"
+                          exit 0
+                      fi
+                      if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+                          BACKOFF=$((attempt * 10))
+                          echo "Login failed, waiting ${BACKOFF}s before retry..."
+                          sleep "$BACKOFF"
+                      fi
+                  done
+                  echo "All $MAX_ATTEMPTS login attempts failed" >&2
+                  exit 1
 
             - name: Pull and inspect image
               run: |


### PR DESCRIPTION
## Summary

2026-05-11 のリリース障害調査で判明した **ghcr.io login の intermittent timeout** に対する対策。

## 問題

本日 6 回の docker login のうち **2 回 (33%) が `Client.Timeout exceeded while awaiting headers` で 15s ジャストで失敗**。再 run でほぼ確実に成功する一過性。

```
##[error]Error response from daemon: Get "https://ghcr.io/v2/":
  net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

調査の結果:

- GitHub プラットフォーム既知問題 ([github/community #182234](https://github.com/orgs/community/discussions/182234))
- GitHub Status にも遡及 [incident vkr22005hg0x](https://www.githubstatus.com/incidents/vkr22005hg0x) として登録済み
- ghcr.io 単体の劣化は status に出にくく、ユーザー側で吸収するのが現実解

## 変更内容

### 1. `docker/login-action@v4` をシェルベース login に置換し最大 3 回までリトライ

線形バックオフ (10s / 20s) で、worst case 約 75s 以内に決着する想定。`--password-stdin` を維持してトークンを露出させない。

### 2. username を `github.actor` → `github.repository_owner` に変更

移管後の master push で `github.actor = vemikrs`（merger 個人）になるが、ログ可読性とパッケージ所有 org との整合のため `vemiorg` 固定にする。認証は GITHUB_TOKEN なので機能影響なし。

### 3. 適用範囲

3 ジョブすべての login step:
- `Build and Push` (matrix: all-in-one / backend-only)
- `Verify All-in-One Image`
- `Verify Backend Image`

## トレードオフ

- `docker/login-action` を外したことで post-step の auto-logout が無くなる。GitHub-hosted runner は ephemeral のため実害なし。
- 退路: もし retry 実装で問題が出たら `docker/login-action@v4` に戻して external retry action (例: `nick-fields/retry@v3`) でラップするオプションあり。

## Test plan

- [ ] このPR merge 後の `Docker Build and Push` run で:
  - [ ] 通常時は 1 回目で login 成功・ログに `[attempt 1/3] ... Login succeeded on attempt 1`
  - [ ] verify ジョブを含めて全ジョブ green
- [ ] 次に ghcr.io タイムアウトが発生した時にリトライで吸収されることを確認（自然発生を待つ）

## 関連

- [PR #275](https://github.com/vemiorg/mirelplatform/pull/275) — release-ui-core のリリース順序入替（同じ移管直後障害の別側面）