### PR TITLE
fix(auth): refresh token rotation・Cookie読み取り・single-flight・proactive refresh

### DIFF
--- a/apps/frontend-v3/src/lib/api/auth.ts
+++ b/apps/frontend-v3/src/lib/api/auth.ts
@@ -99,13 +99,22 @@ export const authApi = {
   },
 
   /**
-   * Refresh access token
+   * Refresh access token.
+   * refreshToken が指定された場合は body に載せる。
+   * 未指定の場合は空 body で POST し、バックエンドが Cookie から refreshToken を読む。
    */
-  async refreshToken(refreshToken: string): Promise<TokenDto> {
+  async refreshToken(refreshToken?: string): Promise<TokenDto> {
     try {
+      const body = refreshToken ? { refreshToken } : {};
       const response = await apiClient.post<AuthenticationResponse>(
         '/auth/refresh',
-        { refreshToken }
+        body,
+        {
+          headers: {
+            // refresh 自体が 401 リトライ対象にならないよう抑制
+            'X-Mirel-Skip-Auth-Redirect': 'true',
+          },
+        }
       );
 
       return response.data.tokens;

--- a/apps/frontend-v3/src/stores/__tests__/authStore.refresh.test.ts
+++ b/apps/frontend-v3/src/stores/__tests__/authStore.refresh.test.ts
@@ -1,0 +1,226 @@
+/**
+ * authStore refresh 関連テスト
+ *
+ * - single-flight: 複数の concurrent refreshAccessToken 呼び出しが 1 回の API コールに集約される
+ * - Cookie フォールバック: tokens がメモリに無い場合でも refreshToken(undefined) で呼べる
+ * - proactive refresh: login 後にタイマーが設定される
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// authApi を mock
+vi.mock('@/lib/api/auth', () => ({
+  authApi: {
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshToken: vi.fn(),
+    switchTenant: vi.fn(),
+  },
+}));
+
+// userProfile API を mock
+vi.mock('@/lib/api/userProfile', () => ({
+  getUserProfile: vi.fn().mockResolvedValue({
+    userId: 'u1',
+    username: 'test',
+    email: 'test@example.com',
+    displayName: 'Test',
+    isActive: true,
+    emailVerified: true,
+  }),
+  getUserTenants: vi.fn().mockResolvedValue([]),
+  getUserLicenses: vi.fn().mockResolvedValue([]),
+}));
+
+// router.config の clearAuthLoaderCache mock
+vi.mock('@/app/router.config', () => ({
+  clearAuthLoaderCache: vi.fn(),
+}));
+
+// miraStore mock
+vi.mock('@/stores/miraStore', () => ({
+  useMiraStore: {
+    persist: { clearStorage: vi.fn() },
+    setState: vi.fn(),
+  },
+}));
+
+import { useAuthStore, _resetRefreshPromise, cancelProactiveRefresh } from '../authStore';
+import { authApi } from '@/lib/api/auth';
+
+describe('authStore - refresh token mechanics', () => {
+  beforeEach(() => {
+    // store をリセット
+    useAuthStore.setState({
+      user: null,
+      currentTenant: null,
+      tokens: null,
+      tenants: [],
+      licenses: [],
+      isAuthenticated: false,
+      otpState: null,
+    });
+    _resetRefreshPromise();
+    cancelProactiveRefresh();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cancelProactiveRefresh();
+  });
+
+  describe('single-flight guard', () => {
+    it('concurrent refreshAccessToken calls should result in only one API call', async () => {
+      // メモリにトークンをセット
+      useAuthStore.setState({
+        tokens: { accessToken: 'old-at', refreshToken: 'old-rt', expiresIn: 3600 },
+        isAuthenticated: true,
+      });
+
+      // refreshToken API に少し遅延を入れる
+      let resolveRefresh!: (value: any) => void;
+      const refreshPromise = new Promise((resolve) => {
+        resolveRefresh = resolve;
+      });
+      vi.mocked(authApi.refreshToken).mockReturnValue(refreshPromise as any);
+
+      // 3 つの concurrent refresh を発火
+      const { refreshAccessToken } = useAuthStore.getState();
+      const p1 = refreshAccessToken();
+      const p2 = refreshAccessToken();
+      const p3 = refreshAccessToken();
+
+      // API はまだ 1 回だけ呼ばれている
+      expect(authApi.refreshToken).toHaveBeenCalledTimes(1);
+      expect(authApi.refreshToken).toHaveBeenCalledWith('old-rt');
+
+      // resolve
+      resolveRefresh({ accessToken: 'new-at', refreshToken: 'new-rt', expiresIn: 3600 });
+
+      const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+      // 全て同じ結果
+      expect(r1).toBe(true);
+      expect(r2).toBe(true);
+      expect(r3).toBe(true);
+
+      // API は依然 1 回だけ
+      expect(authApi.refreshToken).toHaveBeenCalledTimes(1);
+
+      // store のトークンが更新されている
+      expect(useAuthStore.getState().tokens?.accessToken).toBe('new-at');
+      expect(useAuthStore.getState().tokens?.refreshToken).toBe('new-rt');
+    });
+
+    it('after first refresh completes, a new call should make a new API call', async () => {
+      useAuthStore.setState({
+        tokens: { accessToken: 'at1', refreshToken: 'rt1', expiresIn: 3600 },
+        isAuthenticated: true,
+      });
+
+      vi.mocked(authApi.refreshToken)
+        .mockResolvedValueOnce({ accessToken: 'at2', refreshToken: 'rt2', expiresIn: 3600 })
+        .mockResolvedValueOnce({ accessToken: 'at3', refreshToken: 'rt3', expiresIn: 3600 });
+
+      // 1st refresh
+      const result1 = await useAuthStore.getState().refreshAccessToken();
+      expect(result1).toBe(true);
+      expect(authApi.refreshToken).toHaveBeenCalledTimes(1);
+
+      // 2nd refresh (should be a new call)
+      const result2 = await useAuthStore.getState().refreshAccessToken();
+      expect(result2).toBe(true);
+      expect(authApi.refreshToken).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Cookie fallback (no memory token)', () => {
+    it('should call refreshToken with undefined when tokens are null (Cookie fallback)', async () => {
+      // tokens = null → F5 / 新タブを模擬
+      useAuthStore.setState({
+        tokens: null,
+        isAuthenticated: true,
+      });
+
+      vi.mocked(authApi.refreshToken).mockResolvedValue({
+        accessToken: 'cookie-at',
+        refreshToken: 'cookie-rt',
+        expiresIn: 3600,
+      });
+
+      const result = await useAuthStore.getState().refreshAccessToken();
+
+      expect(result).toBe(true);
+      // refreshToken(undefined) → バックエンドが Cookie から読む
+      expect(authApi.refreshToken).toHaveBeenCalledWith(undefined);
+      expect(useAuthStore.getState().tokens?.accessToken).toBe('cookie-at');
+    });
+  });
+
+  describe('proactive refresh', () => {
+    it('should schedule proactive refresh timer after successful refresh', async () => {
+      useAuthStore.setState({
+        tokens: { accessToken: 'at', refreshToken: 'rt', expiresIn: 3600 },
+        isAuthenticated: true,
+      });
+
+      vi.mocked(authApi.refreshToken).mockResolvedValue({
+        accessToken: 'new-at',
+        refreshToken: 'new-rt',
+        expiresIn: 3600, // 1 hour
+      });
+
+      // refresh 前はタイマーなし
+      expect(vi.getTimerCount()).toBe(0);
+
+      // refresh
+      await useAuthStore.getState().refreshAccessToken();
+      expect(authApi.refreshToken).toHaveBeenCalledTimes(1);
+
+      // proactive refresh タイマーが設定されている
+      expect(vi.getTimerCount()).toBe(1);
+    });
+
+    it('should not fire proactive refresh after logout', async () => {
+      useAuthStore.setState({
+        tokens: { accessToken: 'at', refreshToken: 'rt', expiresIn: 3600 },
+        isAuthenticated: true,
+      });
+
+      vi.mocked(authApi.refreshToken).mockResolvedValue({
+        accessToken: 'new-at',
+        refreshToken: 'new-rt',
+        expiresIn: 600, // 10 min → proactive at (600-120)=480s
+      });
+
+      await useAuthStore.getState().refreshAccessToken();
+
+      // logout → cancelProactiveRefresh が呼ばれる
+      cancelProactiveRefresh();
+      useAuthStore.setState({ isAuthenticated: false, tokens: null });
+
+      // タイマーを進めても API は再呼び出しされない
+      vi.advanceTimersByTime(600 * 1000);
+      await vi.runAllTimersAsync();
+
+      // refresh は最初の 1 回のみ
+      expect(authApi.refreshToken).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('refresh failure', () => {
+    it('should return false on API error', async () => {
+      useAuthStore.setState({
+        tokens: { accessToken: 'at', refreshToken: 'rt', expiresIn: 3600 },
+        isAuthenticated: true,
+      });
+
+      vi.mocked(authApi.refreshToken).mockRejectedValue(new Error('401'));
+
+      const result = await useAuthStore.getState().refreshAccessToken();
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/apps/frontend-v3/src/stores/authStore.ts
+++ b/apps/frontend-v3/src/stores/authStore.ts
@@ -3,6 +3,16 @@ import type { OtpPurpose } from '@/lib/api/otp.types';
 import { authApi, type LoginRequest, type SignupRequest, type TokenDto, type TenantContextDto } from '@/lib/api/auth';
 import { getUserProfile, getUserTenants, getUserLicenses, type UserProfile, type TenantInfo, type LicenseInfo } from '@/lib/api/userProfile';
 
+// ── Single-flight guard ──
+// 複数の 401 応答が同時に refreshAccessToken を呼んでも、実際の refresh は 1 回だけ実行される。
+let _refreshPromise: Promise<boolean> | null = null;
+
+// ── Proactive refresh timer ──
+let _proactiveRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+
+/** proactive refresh のバッファ秒数（期限の何秒前に更新するか） */
+const PROACTIVE_REFRESH_BUFFER_SEC = 120; // 2分前
+
 /**
  * OTP認証状態
  */
@@ -66,6 +76,10 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
           tokens: response.tokens,
           isAuthenticated: true,
         });
+        // Proactive refresh タイマー起動
+        if (response.tokens?.expiresIn) {
+          scheduleProactiveRefresh(response.tokens.expiresIn);
+        }
         // Login successful, fetch full profile data
         await get().fetchProfile();
       },
@@ -81,11 +95,17 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
           tokens: response.tokens,
           isAuthenticated: true,
         });
+        // Proactive refresh タイマー起動
+        if (response.tokens?.expiresIn) {
+          scheduleProactiveRefresh(response.tokens.expiresIn);
+        }
         await get().fetchProfile();
       },
 
       logout: async () => {
         console.log('[DEBUG logout] Step 1: Starting logout...');
+        // Proactive refresh タイマーをキャンセル
+        cancelProactiveRefresh();
         const { tokens } = get();
         
         console.log('[DEBUG logout] Step 2: Calling logout API (awaiting)...');
@@ -189,6 +209,18 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
             // HttpOnly Cookie 経由で /users/me が成功している時点で認証済み
             isAuthenticated: true,
           });
+
+          // rehydrate 成功 → proactive refresh をスケジュール
+          // access token の正確な残り時間は不明（Cookie HttpOnly）なので、
+          // tokens がメモリにあれば expiresIn を使い、なければ早めに refresh を試みる
+          const tokens = get().tokens;
+          if (tokens?.expiresIn) {
+            scheduleProactiveRefresh(tokens.expiresIn);
+          } else {
+            // Cookie から復元した場合、access token の残り時間が不明。
+            // 安全のため 5 分後に proactive refresh を試みる。
+            scheduleProactiveRefresh(300);
+          }
         } catch (error) {
           console.error('Failed to rehydrate auth store from server session', error);
           // 401 などの場合は呼び出し側 (authLoader) でリダイレクト制御を行う
@@ -212,30 +244,52 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
       },
 
       /**
-       * リフレッシュトークンを使用してアクセストークンを更新
-       * @returns 更新成功時true、失敗時false
+       * リフレッシュトークンを使用してアクセストークンを更新（single-flight）
+       *
+       * - 同時に複数呼ばれても実際の API コールは 1 回だけ（single-flight ガード）
+       * - メモリに refreshToken があれば body に載せる
+       * - メモリに無い場合（F5/新タブ）は空 body で POST → バックエンドが Cookie から読む
+       * - 成功後に proactive refresh タイマーを再スケジュール
+       *
+       * @returns 更新成功時 true、失敗時 false
        */
       refreshAccessToken: async () => {
-        try {
-          const { tokens } = get();
-          if (!tokens?.refreshToken) {
-            console.log('[Auth] No refresh token available');
-            return false;
-          }
-
-          console.log('[Auth] Refreshing access token...');
-          const response = await authApi.refreshToken(tokens.refreshToken);
-          // refreshTokenはTokenDtoを直接返す
-          set({
-            tokens: response,
-          });
-          
-          console.log('[Auth] Access token refreshed successfully');
-          return true;
-        } catch (error) {
-          console.error('[Auth] Failed to refresh access token', error);
-          return false;
+        // single-flight: 進行中の refresh があればそれを待つ
+        if (_refreshPromise) {
+          console.log('[Auth] Refresh already in flight, waiting...');
+          return _refreshPromise;
         }
+
+        _refreshPromise = (async () => {
+          try {
+            const { tokens } = get();
+            // メモリに refreshToken があれば使う、なければ Cookie にフォールバック（body 空）
+            const refreshTokenValue = tokens?.refreshToken;
+
+            console.log('[Auth] Refreshing access token...', {
+              hasMemoryToken: !!refreshTokenValue,
+              fallbackToCookie: !refreshTokenValue,
+            });
+
+            const response = await authApi.refreshToken(refreshTokenValue);
+
+            // rotation 後の新トークンをストアに反映
+            set({ tokens: response });
+
+            // proactive refresh タイマーを再スケジュール
+            scheduleProactiveRefresh(response.expiresIn);
+
+            console.log('[Auth] Access token refreshed successfully (rotation applied)');
+            return true;
+          } catch (error) {
+            console.error('[Auth] Failed to refresh access token', error);
+            return false;
+          } finally {
+            _refreshPromise = null;
+          }
+        })();
+
+        return _refreshPromise;
       },
 
       updateUser: (updatedUser: Partial<UserProfile>) => {
@@ -271,6 +325,50 @@ export const useAuthStore = create<AuthState>()((set, get) => ({
       },
     })
 );
+
+/**
+ * Proactive refresh: access token の有効期限の数分前にバックグラウンドで refresh を実行。
+ * これにより「リクエスト失敗 → 401 → リトライ」のラグを回避する。
+ *
+ * @param expiresInSec access token の残り有効期限（秒）
+ */
+function scheduleProactiveRefresh(expiresInSec: number) {
+  // 既存タイマーをクリア
+  if (_proactiveRefreshTimer) {
+    clearTimeout(_proactiveRefreshTimer);
+    _proactiveRefreshTimer = null;
+  }
+
+  // バッファを引いた時間後にリフレッシュ実行
+  const delaySec = Math.max(expiresInSec - PROACTIVE_REFRESH_BUFFER_SEC, 10);
+  console.log(`[Auth] Proactive refresh scheduled in ${delaySec}s (token expires in ${expiresInSec}s)`);
+
+  _proactiveRefreshTimer = setTimeout(async () => {
+    console.log('[Auth] Proactive refresh firing...');
+    const { refreshAccessToken, isAuthenticated } = useAuthStore.getState();
+    if (!isAuthenticated) {
+      console.log('[Auth] Not authenticated, skipping proactive refresh');
+      return;
+    }
+    const success = await refreshAccessToken();
+    if (!success) {
+      console.warn('[Auth] Proactive refresh failed — user may be logged out on next API call');
+    }
+  }, delaySec * 1000);
+}
+
+/** Cancel the proactive refresh timer (on logout). Exported for testing. */
+export function cancelProactiveRefresh() {
+  if (_proactiveRefreshTimer) {
+    clearTimeout(_proactiveRefreshTimer);
+    _proactiveRefreshTimer = null;
+  }
+}
+
+/** Reset the single-flight guard (for testing only). */
+export function _resetRefreshPromise() {
+  _refreshPromise = null;
+}
 
 /**
  * 機密性の高いローカルストレージデータをクリアするヘルパー

--- a/backend/src/main/java/jp/vemi/mirel/WebSecurityConfig.java
+++ b/backend/src/main/java/jp/vemi/mirel/WebSecurityConfig.java
@@ -244,11 +244,13 @@ public class WebSecurityConfig {
                     .requestMatchers("/swagger-ui.html").permitAll() // Swagger UI HTML
                     .requestMatchers("/apps/mira/api/health").permitAll(); // Mira Health Check
 
+            // refresh は Cookie の refreshToken で認証するため permitAll
+            authz.requestMatchers("/auth/refresh").permitAll();
+
             // 認証必須エンドポイント
             authz.requestMatchers(
                     "/auth/me",
-                    "/auth/switch-tenant",
-                    "/auth/refresh").authenticated();
+                    "/auth/switch-tenant").authenticated();
 
             // セキュリティ無効時は全てのAPIをパブリックに
             if (!securityProperties.isEnabled()) {

--- a/backend/src/main/java/jp/vemi/mirel/config/properties/AuthProperties.java
+++ b/backend/src/main/java/jp/vemi/mirel/config/properties/AuthProperties.java
@@ -42,7 +42,14 @@ public class AuthProperties {
 
         /**
          * リフレッシュトークン有効期限 (秒)
+         * デフォルト: 7日 (604800秒)。Cookie maxAge と一致させること。
          */
-        private long refreshExpiration = 86400;
+        private long refreshExpiration = 604800;
+
+        /**
+         * rememberMe 有効時のリフレッシュトークン有効期限 (秒)
+         * デフォルト: 90日
+         */
+        private long rememberMeRefreshExpiration = 7776000;
     }
 }

--- a/backend/src/main/java/jp/vemi/mirel/foundation/abst/dao/entity/RefreshToken.java
+++ b/backend/src/main/java/jp/vemi/mirel/foundation/abst/dao/entity/RefreshToken.java
@@ -46,6 +46,14 @@ public class RefreshToken {
     @Column(name = "revoked_at")
     private Instant revokedAt;
 
+    /**
+     * Token rotation: このトークンを置き換えた新トークンのハッシュ。
+     * 再利用検知: revoked済みのトークンが再提示された場合、
+     * このフィールドが non-null なら theft とみなしユーザーの全トークンを revoke する。
+     */
+    @Column(name = "replaced_by_token_hash")
+    private String replacedByTokenHash;
+
     /** バージョン */
     @Version
     @Column(name = "version", nullable = false)

--- a/backend/src/main/java/jp/vemi/mirel/foundation/abst/dao/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/jp/vemi/mirel/foundation/abst/dao/repository/RefreshTokenRepository.java
@@ -37,4 +37,11 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Stri
      */
     @Query("DELETE FROM RefreshToken rt WHERE rt.expiresAt < :now OR rt.revokedAt IS NOT NULL")
     void deleteExpiredTokens(@Param("now") Instant now);
+
+    /**
+     * ユーザーの全有効トークンを取得（再利用検知時の一括 revoke 用）
+     */
+    @Query("SELECT rt FROM RefreshToken rt WHERE rt.userId = :userId AND " +
+           "rt.revokedAt IS NULL AND rt.deleteFlag = false")
+    List<RefreshToken> findAllActiveByUserId(@Param("userId") String userId);
 }

--- a/backend/src/main/java/jp/vemi/mirel/foundation/web/api/auth/controller/AuthenticationController.java
+++ b/backend/src/main/java/jp/vemi/mirel/foundation/web/api/auth/controller/AuthenticationController.java
@@ -40,6 +40,9 @@ public class AuthenticationController {
     @Autowired
     private PasswordResetService passwordResetService;
 
+    @Autowired
+    private jp.vemi.mirel.config.properties.AuthProperties authProperties;
+
     /**
      * ログイン
      */
@@ -167,15 +170,34 @@ public class AuthenticationController {
 
     /**
      * トークンリフレッシュ
+     * body の refreshToken を優先し、未指定なら Cookie "refreshToken" にフォールバック。
+     * これにより F5/新規タブ後もメモリが空でも Cookie 経由で refresh 可能。
      */
     @PostMapping("/refresh")
     public ResponseEntity<AuthenticationResponse> refresh(
-            @RequestBody RefreshTokenRequest request,
+            @RequestBody(required = false) RefreshTokenRequest request,
+            HttpServletRequest httpRequest,
             HttpServletResponse httpResponse) {
         try {
+            // body から refreshToken を取得、なければ Cookie から取得
+            String refreshTokenValue = (request != null && request.getRefreshToken() != null)
+                    ? request.getRefreshToken()
+                    : resolveRefreshTokenFromCookie(httpRequest);
+
+            if (refreshTokenValue == null || refreshTokenValue.isEmpty()) {
+                logger.warn("Token refresh failed: no refresh token in body or cookie");
+                return ResponseEntity.status(401).build();
+            }
+
+            // 統一した refreshToken を使って request を組み立て
+            if (request == null) {
+                request = new RefreshTokenRequest();
+            }
+            request.setRefreshToken(refreshTokenValue);
+
             AuthenticationResponse response = authenticationService.refresh(request);
 
-            // Set access token in HttpOnly cookie
+            // Set tokens in HttpOnly cookies (access + new refresh after rotation)
             if (response.getTokens() != null) {
                 setTokenCookies(httpResponse, response.getTokens());
             }
@@ -185,6 +207,21 @@ public class AuthenticationController {
             logger.error("Token refresh failed: {}", e.getMessage());
             return ResponseEntity.status(401).build();
         }
+    }
+
+    /**
+     * HttpServletRequest の Cookie から refreshToken を取得
+     */
+    private String resolveRefreshTokenFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("refreshToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
     }
 
     /**
@@ -419,7 +456,8 @@ public class AuthenticationController {
     }
 
     /**
-     * Set JWT tokens as HttpOnly cookies
+     * Set JWT tokens as HttpOnly cookies.
+     * Cookie maxAge は AuthProperties の値と一致させる。
      */
     private void setTokenCookies(HttpServletResponse response, TokenDto tokens) {
         // Access token cookie (HttpOnly, Secure in production)
@@ -427,7 +465,7 @@ public class AuthenticationController {
         accessTokenCookie.setHttpOnly(true);
         accessTokenCookie.setSecure(false); // Set true in production with HTTPS
         accessTokenCookie.setPath("/");
-        accessTokenCookie.setMaxAge(60 * 60); // 1 hour
+        accessTokenCookie.setMaxAge((int) authProperties.getJwt().getExpiration()); // auth.jwt.expiration (default 1h)
         response.addCookie(accessTokenCookie);
 
         // Refresh token cookie (HttpOnly, Secure in production)
@@ -435,7 +473,7 @@ public class AuthenticationController {
         refreshTokenCookie.setHttpOnly(true);
         refreshTokenCookie.setSecure(false); // Set true in production with HTTPS
         refreshTokenCookie.setPath("/");
-        refreshTokenCookie.setMaxAge(60 * 60 * 24 * 7); // 7 days
+        refreshTokenCookie.setMaxAge((int) authProperties.getJwt().getRefreshExpiration()); // auth.jwt.refreshExpiration (default 7d)
         response.addCookie(refreshTokenCookie);
 
         logger.debug("JWT tokens set in HttpOnly cookies");

--- a/backend/src/main/java/jp/vemi/mirel/foundation/web/api/auth/service/AuthenticationServiceImpl.java
+++ b/backend/src/main/java/jp/vemi/mirel/foundation/web/api/auth/service/AuthenticationServiceImpl.java
@@ -28,6 +28,17 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
+ * Refresh token の再利用検知時にスローされる例外。
+ * 全トークン revoke をコミットする必要があるため、
+ * この例外では @Transactional のロールバックを抑制する。
+ */
+class RefreshTokenReuseException extends jp.vemi.framework.exeption.MirelValidationException {
+    RefreshTokenReuseException(String message) {
+        super(message);
+    }
+}
+
+/**
  * 認証サービス実装.
  */
 @org.springframework.stereotype.Service
@@ -498,9 +509,17 @@ public class AuthenticationServiceImpl {
     }
 
     /**
-     * トークンリフレッシュ
+     * トークンリフレッシュ（Token Rotation + 再利用検知 + Sliding Expiry）
+     *
+     * <ol>
+     *   <li>提示された refresh token を検証</li>
+     *   <li>再利用検知: revoked 済み（= 既に rotation 済み）のトークンが再提示された場合、
+     *       トークン盗難とみなしユーザーの全トークンを revoke</li>
+     *   <li>旧トークンを revoke し、新トークンを発行（rotation）</li>
+     *   <li>新トークンの有効期限は now + refreshExpiration（sliding expiry）</li>
+     * </ol>
      */
-    @Transactional
+    @Transactional(noRollbackFor = RefreshTokenReuseException.class)
     public AuthenticationResponse refresh(RefreshTokenRequest request) {
         boolean isJwtEnabled = authProperties.getJwt().isEnabled();
         if (!isJwtEnabled || jwtService == null) {
@@ -508,40 +527,67 @@ public class AuthenticationServiceImpl {
         }
         log.info("Token refresh attempt");
 
-        // RefreshToken検証
+        // RefreshToken 検索
         String tokenHash = hashToken(request.getRefreshToken());
-        RefreshToken refreshToken = refreshTokenRepository.findByTokenHash(tokenHash)
+        RefreshToken oldRefreshToken = refreshTokenRepository.findByTokenHash(tokenHash)
                 .orElseThrow(() -> new jp.vemi.framework.exeption.MirelValidationException("Invalid refresh token"));
 
-        if (!refreshToken.isValid()) {
+        // ── 再利用検知 ──
+        // revoked 済みトークンが再提示された → 盗難の可能性 → 全トークン revoke
+        if (oldRefreshToken.getRevokedAt() != null) {
+            log.warn("Refresh token reuse detected for user: {}. Revoking all tokens.", oldRefreshToken.getUserId());
+            authEventLogger.logLoginFailure(oldRefreshToken.getUserId(),
+                    "Refresh token reuse detected (possible theft)", "unknown", "unknown");
+            revokeAllUserTokens(oldRefreshToken.getUserId());
+            throw new RefreshTokenReuseException(
+                    "Refresh token reuse detected. All sessions have been revoked for security.");
+        }
+
+        // 通常の有効性チェック（期限切れ, deleteFlag）
+        if (!oldRefreshToken.isValid()) {
             throw new jp.vemi.framework.exeption.MirelValidationException("Refresh token is expired or revoked");
         }
 
         // ユーザー取得
-        User user = userRepository.findById(refreshToken.getUserId())
+        User user = userRepository.findById(oldRefreshToken.getUserId())
                 .orElseThrow(() -> new jp.vemi.framework.exeption.MirelSystemException("User not found"));
 
         // テナント取得
         Tenant tenant = user.getTenantId() != null ? tenantRepository.findById(user.getTenantId()).orElse(null) : null;
 
-        // 新しいアクセストークン生成
-        String accessToken;
-        if (isJwtEnabled && jwtService != null) {
-            accessToken = jwtService.generateToken(
-                    new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
-                            user.getUserId(), null, List.of()));
-        } else {
-            accessToken = "session-based-auth-token";
-            log.warn("JWT is disabled. Using session-based authentication placeholder.");
-        }
+        // ── Token Rotation: 新トークン発行 + 旧トークン revoke ──
+        RefreshToken newRefreshToken = createRefreshToken(user);  // sliding expiry: expiresAt = now + refreshExpiration
+
+        // 旧トークンを revoke し、後継を記録（再利用検知チェーン用）
+        oldRefreshToken.setRevokedAt(Instant.now());
+        oldRefreshToken.setReplacedByTokenHash(hashToken(newRefreshToken.getTokenHash())); // tokenHash は一時的に tokenValue を保持
+        refreshTokenRepository.save(oldRefreshToken);
+
+        // ── 新しいアクセストークン生成（権限を正しく載せる） ──
+        String accessToken = jwtService.generateToken(
+                new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
+                        user.getUserId(), null, buildAuthoritiesFromUser(user)));
 
         // 有効ライセンス取得
         List<ApplicationLicense> licenses = licenseRepository.findEffectiveLicenses(
                 user.getUserId(), tenant != null ? tenant.getTenantId() : null, Instant.now());
 
-        log.info("Token refresh successful for user: {}", user.getUserId());
+        log.info("Token refresh successful (rotation) for user: {}", user.getUserId());
 
-        return buildAuthenticationResponse(user, tenant, accessToken, request.getRefreshToken(), licenses);
+        return buildAuthenticationResponse(user, tenant, accessToken, newRefreshToken.getTokenHash(), licenses);
+    }
+
+    /**
+     * ユーザーの全有効トークンを revoke（再利用検知時）
+     */
+    private void revokeAllUserTokens(String userId) {
+        List<RefreshToken> activeTokens = refreshTokenRepository.findAllActiveByUserId(userId);
+        Instant now = Instant.now();
+        for (RefreshToken token : activeTokens) {
+            token.setRevokedAt(now);
+            refreshTokenRepository.save(token);
+        }
+        log.info("Revoked {} active tokens for user: {}", activeTokens.size(), userId);
     }
 
     /**
@@ -686,23 +732,27 @@ public class AuthenticationServiceImpl {
 
     /**
      * RefreshToken作成
-     * 
+     *
      * @param user
      *            ユーザー
      * @param rememberMe
-     *            ログイン状態を永続化するか（true: 90日, false: 1日）
+     *            ログイン状態を永続化するか
+     *            true: auth.jwt.rememberMeRefreshExpiration (デフォルト90日)
+     *            false: auth.jwt.refreshExpiration (デフォルト7日)
      */
     private RefreshToken createRefreshToken(User user, boolean rememberMe) {
         String tokenValue = UUID.randomUUID().toString();
         String tokenHash = hashToken(tokenValue);
 
-        // rememberMeに応じて有効期限を設定
-        long expirationDays = rememberMe ? 90 : 1;
+        // AuthProperties からリフレッシュトークン有効期限を取得
+        long expirationSeconds = rememberMe
+                ? authProperties.getJwt().getRememberMeRefreshExpiration()
+                : authProperties.getJwt().getRefreshExpiration();
 
         RefreshToken refreshToken = new RefreshToken();
         refreshToken.setUserId(user.getUserId());
         refreshToken.setTokenHash(tokenHash);
-        refreshToken.setExpiresAt(Instant.now().plus(expirationDays, ChronoUnit.DAYS));
+        refreshToken.setExpiresAt(Instant.now().plusSeconds(expirationSeconds));
         refreshToken.setDeviceInfo("web");
         refreshTokenRepository.save(refreshToken);
 
@@ -712,7 +762,7 @@ public class AuthenticationServiceImpl {
     }
 
     /**
-     * RefreshToken作成（デフォルト: 30日）
+     * RefreshToken作成（デフォルト: 非rememberMe）
      * 後方互換性のためのオーバーロード
      */
     private RefreshToken createRefreshToken(User user) {

--- a/backend/src/main/java/jp/vemi/mirel/security/CookieOrHeaderBearerTokenResolver.java
+++ b/backend/src/main/java/jp/vemi/mirel/security/CookieOrHeaderBearerTokenResolver.java
@@ -39,6 +39,7 @@ public class CookieOrHeaderBearerTokenResolver implements BearerTokenResolver {
             "/auth/logout",
             "/auth/health",
             "/auth/otp/",
+            "/auth/refresh",
             "/auth/verify-setup-token",
             "/auth/setup-account",
             "/api/bootstrap/",

--- a/backend/src/test/java/jp/vemi/mirel/security/RefreshTokenRotationIntegrationTest.java
+++ b/backend/src/test/java/jp/vemi/mirel/security/RefreshTokenRotationIntegrationTest.java
@@ -1,0 +1,366 @@
+package jp.vemi.mirel.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.Cookie;
+import jp.vemi.mirel.foundation.abst.dao.entity.RefreshToken;
+import jp.vemi.mirel.foundation.abst.dao.entity.SystemUser;
+import jp.vemi.mirel.foundation.abst.dao.entity.User;
+import jp.vemi.mirel.foundation.abst.dao.repository.RefreshTokenRepository;
+import jp.vemi.mirel.foundation.abst.dao.repository.SystemUserRepository;
+import jp.vemi.mirel.foundation.abst.dao.repository.UserRepository;
+// VectorStore は e2e プロファイル (Postgres + pgvector) で動作するため mock 不要
+
+/**
+ * Refresh Token Rotation 統合テスト.
+ *
+ * <ul>
+ *   <li>P0-1: Cookie からの refresh token 読み取り</li>
+ *   <li>P0-2: RT 寿命が AuthProperties と一致</li>
+ *   <li>P1-3: Token rotation（旧 RT revoke + 新 RT 発行）</li>
+ *   <li>P1-3: 再利用検知（revoked RT 再提示 → 全 RT revoke）</li>
+ *   <li>P1-4: Sliding expiry（refresh のたびに新 RT の期限が延長）</li>
+ *   <li>P1-6: refresh 後の JWT に権限（roles）が含まれること</li>
+ * </ul>
+ */
+@SpringBootTest(properties = {
+        "spring.main.allow-bean-definition-overriding=true",
+        "auth.method=jwt",
+        "auth.jwt.enabled=true",
+        "auth.jwt.secret=verylongsecretkeythatisatleast32byteslongforsecurityreasons",
+        "auth.jwt.expiration=3600",
+        "auth.jwt.refresh-expiration=604800",
+        "mipla2.security.api.csrf-enabled=false",
+        "mira.ai.provider=mock",
+        "mira.ai.mock.enabled=true",
+        // Docker Compose dev 環境の Postgres に接続
+        "spring.datasource.url=jdbc:postgresql://localhost:5432/mirelplatform",
+        "spring.datasource.username=mirel",
+        "spring.datasource.password=mirel"
+})
+@AutoConfigureMockMvc
+@ActiveProfiles("e2e")
+@DisplayName("Refresh Token Rotation 統合テスト")
+public class RefreshTokenRotationIntegrationTest {
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        @Primary
+        ChatModel mockChatModel() {
+            return mock(ChatModel.class);
+        }
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private SystemUserRepository systemUserRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private static final String EMAIL = "refresh-test@example.com";
+    private static final String USER_ID = "user-refresh-test-001";
+    private static final String PASSWORD = "password123";
+
+    @BeforeEach
+    void setUp() {
+        // 既存テストデータを削除
+        userRepository.findById(USER_ID).ifPresent(u -> userRepository.delete(u));
+        systemUserRepository.findByEmail(EMAIL).ifPresent(su -> systemUserRepository.delete(su));
+        // テストユーザーの既存リフレッシュトークンも削除
+        refreshTokenRepository.findValidTokensByUserId(USER_ID, Instant.EPOCH)
+                .forEach(rt -> refreshTokenRepository.delete(rt));
+
+        // SystemUser 作成
+        SystemUser su = new SystemUser();
+        su.setId(UUID.fromString("550e8400-e29b-41d4-a716-446655440099"));
+        su.setUsername("refreshuser");
+        su.setEmail(EMAIL);
+        su.setPasswordHash(passwordEncoder.encode(PASSWORD));
+        su.setEmailVerified(true);
+        su.setIsActive(true);
+        su.setAccountLocked(false);
+        systemUserRepository.save(su);
+
+        // Application User 作成
+        User appUser = new User();
+        appUser.setUserId(USER_ID);
+        appUser.setSystemUserId(su.getId());
+        appUser.setTenantId("default");
+        appUser.setUsername("refreshuser");
+        appUser.setEmail(EMAIL);
+        appUser.setDisplayName("Refresh Test User");
+        appUser.setIsActive(true);
+        appUser.setEmailVerified(true);
+        appUser.setRoles("USER,ADMIN");
+        appUser.setLastLoginAt(Instant.now());
+        userRepository.save(appUser);
+    }
+
+    /**
+     * ログインしてトークンを取得するヘルパー
+     */
+    private JsonNode loginAndGetTokens() throws Exception {
+        String loginPayload = String.format(
+                "{\"usernameOrEmail\":\"%s\",\"password\":\"%s\"}", EMAIL, PASSWORD);
+
+        MvcResult result = mockMvc.perform(post("/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(loginPayload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tokens.accessToken").exists())
+                .andExpect(jsonPath("$.tokens.refreshToken").exists())
+                .andReturn();
+
+        return objectMapper.readTree(result.getResponse().getContentAsString());
+    }
+
+    @Test
+    @DisplayName("Token Rotation: refresh で新 RT 発行 + 旧 RT が revoke される")
+    void refreshShouldRotateToken() throws Exception {
+        // 1. Login
+        JsonNode loginResponse = loginAndGetTokens();
+        String oldRefreshToken = loginResponse.path("tokens").path("refreshToken").asText();
+
+        // 2. Refresh (body に refreshToken を載せる)
+        String refreshPayload = String.format("{\"refreshToken\":\"%s\"}", oldRefreshToken);
+        MvcResult refreshResult = mockMvc.perform(post("/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(refreshPayload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tokens.accessToken").exists())
+                .andExpect(jsonPath("$.tokens.refreshToken").exists())
+                .andReturn();
+
+        JsonNode refreshResponse = objectMapper.readTree(refreshResult.getResponse().getContentAsString());
+        String newRefreshToken = refreshResponse.path("tokens").path("refreshToken").asText();
+
+        // 3. 新旧が異なることを確認（rotation）
+        assertThat(newRefreshToken).isNotEqualTo(oldRefreshToken);
+
+        // 4. 新 RT で再度 refresh できることを確認
+        String refresh2Payload = String.format("{\"refreshToken\":\"%s\"}", newRefreshToken);
+        mockMvc.perform(post("/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(refresh2Payload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tokens.refreshToken").exists());
+    }
+
+    @Test
+    @DisplayName("再利用検知: 旧 RT を再利用すると 401 + 全トークン revoke")
+    void reuseDetectionShouldRevokeAllTokens() throws Exception {
+        // 1. Login
+        JsonNode loginResponse = loginAndGetTokens();
+        String originalRefreshToken = loginResponse.path("tokens").path("refreshToken").asText();
+
+        // 2. 正常 refresh → rotation が行われ旧 RT は revoke
+        String refreshPayload = String.format("{\"refreshToken\":\"%s\"}", originalRefreshToken);
+        MvcResult refreshResult = mockMvc.perform(post("/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(refreshPayload))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode refreshResponse = objectMapper.readTree(refreshResult.getResponse().getContentAsString());
+        String newRefreshToken = refreshResponse.path("tokens").path("refreshToken").asText();
+
+        // 3. 旧 RT を再利用 → 再利用検知で 401
+        mockMvc.perform(post("/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(refreshPayload))  // 旧 RT
+                .andExpect(status().isUnauthorized());
+
+        // 4. 新 RT も revoke されているはず → 401
+        String newRefreshPayload = String.format("{\"refreshToken\":\"%s\"}", newRefreshToken);
+        mockMvc.perform(post("/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(newRefreshPayload))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Cookie フォールバック: body なしで Cookie の refreshToken から refresh 可能")
+    void cookieFallbackRefresh() throws Exception {
+        // 1. Login して Cookie を取得
+        String loginPayload = String.format(
+                "{\"usernameOrEmail\":\"%s\",\"password\":\"%s\"}", EMAIL, PASSWORD);
+
+        MvcResult loginResult = mockMvc.perform(post("/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(loginPayload))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // レスポンスから refreshToken Cookie を抽出
+        jakarta.servlet.http.Cookie refreshCookie = loginResult.getResponse().getCookie("refreshToken");
+        assertThat(refreshCookie).isNotNull();
+        assertThat(refreshCookie.getValue()).isNotEmpty();
+
+        // 2. body なし（= F5後メモリ消失を模擬）+ Cookie のみで refresh
+        MvcResult refreshResult = mockMvc.perform(post("/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}")  // body 空
+                .cookie(new Cookie("refreshToken", refreshCookie.getValue())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tokens.accessToken").exists())
+                .andExpect(jsonPath("$.tokens.refreshToken").exists())
+                .andReturn();
+
+        // 3. rotation により新しい refreshToken Cookie が返される
+        jakarta.servlet.http.Cookie newRefreshCookie = refreshResult.getResponse().getCookie("refreshToken");
+        assertThat(newRefreshCookie).isNotNull();
+        assertThat(newRefreshCookie.getValue()).isNotEqualTo(refreshCookie.getValue());
+    }
+
+    @Test
+    @DisplayName("Sliding Expiry: refresh のたびに新 RT の有効期限が延長される")
+    void slidingExpiry() throws Exception {
+        // 1. Login
+        JsonNode loginResponse = loginAndGetTokens();
+        String refreshToken = loginResponse.path("tokens").path("refreshToken").asText();
+
+        Instant beforeRefresh = Instant.now();
+
+        // 2. Refresh
+        String refreshPayload = String.format("{\"refreshToken\":\"%s\"}", refreshToken);
+        MvcResult refreshResult = mockMvc.perform(post("/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(refreshPayload))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode refreshResponse = objectMapper.readTree(refreshResult.getResponse().getContentAsString());
+        String newRefreshToken = refreshResponse.path("tokens").path("refreshToken").asText();
+
+        // 3. 新 RT の DB レコードを確認 → expiresAt が refresh 時点から 7 日後付近であること
+        // (createRefreshToken が hashToken(tokenValue) で保存するため、ここでは hash を計算して検索)
+        java.security.MessageDigest digest = java.security.MessageDigest.getInstance("SHA-256");
+        byte[] hash = digest.digest(newRefreshToken.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        StringBuilder hexString = new StringBuilder();
+        for (byte b : hash) {
+            String hex = Integer.toHexString(0xff & b);
+            if (hex.length() == 1) hexString.append('0');
+            hexString.append(hex);
+        }
+
+        RefreshToken newRt = refreshTokenRepository.findByTokenHash(hexString.toString())
+                .orElseThrow(() -> new AssertionError("New refresh token not found in DB"));
+
+        // expiresAt は now + 604800秒(7日) に近い値であること（前後 30 秒の誤差を許容）
+        Instant expectedExpiry = beforeRefresh.plusSeconds(604800);
+        assertThat(newRt.getExpiresAt()).isBetween(
+                expectedExpiry.minusSeconds(30),
+                expectedExpiry.plusSeconds(30));
+    }
+
+    @Test
+    @DisplayName("JWT権限: refresh 後のアクセストークンにロール情報が含まれる")
+    void refreshShouldPreserveRolesInJwt() throws Exception {
+        // 1. Login
+        JsonNode loginResponse = loginAndGetTokens();
+        String refreshToken = loginResponse.path("tokens").path("refreshToken").asText();
+
+        // 2. Refresh
+        String refreshPayload = String.format("{\"refreshToken\":\"%s\"}", refreshToken);
+        MvcResult refreshResult = mockMvc.perform(post("/auth/refresh")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(refreshPayload))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode refreshResponse = objectMapper.readTree(refreshResult.getResponse().getContentAsString());
+        String newAccessToken = refreshResponse.path("tokens").path("accessToken").asText();
+
+        // 3. 新 access token で /auth/me にアクセス可能であること
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get("/auth/me")
+                .header("Authorization", "Bearer " + newAccessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.user.userId").value(USER_ID));
+
+        // 4. JWT をデコードして roles claim を確認
+        // JWT は header.payload.signature の形式
+        String[] parts = newAccessToken.split("\\.");
+        assertThat(parts).hasSize(3);
+
+        String payloadJson = new String(java.util.Base64.getUrlDecoder().decode(parts[1]));
+        JsonNode payload = objectMapper.readTree(payloadJson);
+
+        assertThat(payload.has("roles")).isTrue();
+        assertThat(payload.get("roles").isArray()).isTrue();
+        assertThat(payload.get("roles").size()).isGreaterThanOrEqualTo(1);
+
+        // roles に ROLE_USER と ROLE_ADMIN が含まれること
+        boolean hasUser = false, hasAdmin = false;
+        for (JsonNode role : payload.get("roles")) {
+            if (role.asText().equals("ROLE_USER")) hasUser = true;
+            if (role.asText().equals("ROLE_ADMIN")) hasAdmin = true;
+        }
+        assertThat(hasUser).as("JWT should contain ROLE_USER").isTrue();
+        assertThat(hasAdmin).as("JWT should contain ROLE_ADMIN").isTrue();
+    }
+
+    @Test
+    @DisplayName("refresh Cookie の maxAge が AuthProperties.refreshExpiration と一致")
+    void refreshCookieMaxAgeShouldMatchConfig() throws Exception {
+        // Login
+        String loginPayload = String.format(
+                "{\"usernameOrEmail\":\"%s\",\"password\":\"%s\"}", EMAIL, PASSWORD);
+
+        MvcResult loginResult = mockMvc.perform(post("/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(loginPayload))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // refreshToken Cookie の maxAge を確認
+        jakarta.servlet.http.Cookie refreshCookie = loginResult.getResponse().getCookie("refreshToken");
+        assertThat(refreshCookie).isNotNull();
+        // auth.jwt.refresh-expiration=604800 (7日)
+        assertThat(refreshCookie.getMaxAge()).isEqualTo(604800);
+
+        // accessToken Cookie の maxAge を確認
+        jakarta.servlet.http.Cookie accessCookie = loginResult.getResponse().getCookie("accessToken");
+        assertThat(accessCookie).isNotNull();
+        // auth.jwt.expiration=3600 (1時間)
+        assertThat(accessCookie.getMaxAge()).isEqualTo(3600);
+    }
+}


### PR DESCRIPTION
## Summary

認証トークンが頻繁に切れる問題（リロード即死・active ユーザーの強制ログアウト）の根本修正。

### P0 (応急・即効)
- **Cookie refresh フォールバック**: `/auth/refresh` が Cookie の `refreshToken` からも読めるようにし、F5/新タブ後のリロード即死を解消
- **permitAll 化**: `/auth/refresh` を `permitAll` + `SKIP_JWT_PATHS` に追加し、期限切れ accessToken Cookie による誤った 401 を防止
- **RT 寿命統一**: DB(旧1日) と Cookie(7日) の食い違いを解消。`AuthProperties.refreshExpiration` = 7日に統一

### P1 (根治)
- **Token rotation**: refresh のたびに新 RT 発行 + 旧 RT revoke
- **再利用検知**: revoked RT が再提示された場合、盗難とみなしユーザーの全 RT を revoke（`noRollbackFor` でコミット保証）
- **Sliding expiry**: 新 RT の有効期限は `now + refreshExpiration` → アクティブユーザーは事実上切れない
- **JWT 権限修正**: refresh 後の access token に roles claim が欠落するバグを修正（`List.of()` → `buildAuthoritiesFromUser(user)`）
- **Single-flight**: フロントの並列 401 が 1 回の refresh API コールに集約
- **Proactive refresh**: access token 期限の 2 分前にバックグラウンド更新（reactive 401 リトライを回避）

### スキーマ変更
```sql
ALTER TABLE mir_refresh_token ADD COLUMN replaced_by_token_hash VARCHAR(255);
```
`ddl-auto=update` 環境（dev/e2e）では Hibernate 自動追加。本番は手動適用が必要。

## 変更ファイル

| 領域 | ファイル | 変更 |
|---|---|---|
| Backend | `WebSecurityConfig.java` | `/auth/refresh` を permitAll に |
| Backend | `CookieOrHeaderBearerTokenResolver.java` | SKIP_JWT_PATHS に `/auth/refresh` 追加 |
| Backend | `AuthenticationController.java` | Cookie refreshToken フォールバック、maxAge 統一 |
| Backend | `AuthenticationServiceImpl.java` | rotation + 再利用検知 + sliding + 権限修正 |
| Backend | `AuthProperties.java` | refreshExpiration=7日、rememberMeRefreshExpiration=90日 |
| Backend | `RefreshToken.java` | `replacedByTokenHash` カラム追加 |
| Backend | `RefreshTokenRepository.java` | `findAllActiveByUserId` 追加 |
| Frontend | `auth.ts` | refreshToken optional 化 + Cookie フォールバック |
| Frontend | `authStore.ts` | single-flight + proactive refresh + Cookie フォールバック |

## Test plan

- [x] バックエンド統合テスト（6テスト全パス）
  - Token rotation（旧 RT revoke + 新 RT 発行確認）
  - 再利用検知（revoked RT → 全 RT revoke → 新 RT も無効化）
  - Cookie フォールバック（body 空 + Cookie のみで refresh 成功）
  - Sliding expiry（新 RT の expiresAt が refresh 時点から 7 日後）
  - JWT 権限保持（refresh 後の JWT に ROLE_USER, ROLE_ADMIN が含まれる）
  - Cookie maxAge が AuthProperties と一致
- [x] フロントエンド単体テスト（6テスト全パス）
  - Single-flight（3 concurrent 呼び出しが 1 API コールに集約）
  - 完了後の新規呼び出しは新 API コール
  - Cookie フォールバック（tokens=null 時に `refreshToken(undefined)` で呼び出し）
  - Proactive refresh タイマー設定
  - Logout 後タイマーキャンセル
  - API エラー時に false 返却
- [ ] 本番環境でのスキーマ変更（手動 ALTER TABLE）
- [ ] HTTPS 環境での Cookie `secure=true` 設定（P2 スコープ）