### PR TITLE
chore(ci): add job timeout-minutes & bump Playwright

### DIFF
--- a/.github/workflows/build-frontend-artifact.yml
+++ b/.github/workflows/build-frontend-artifact.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
     build-and-release:
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         steps:
             - uses: actions/checkout@v6
               with:

--- a/.github/workflows/ci-ui-package.yml
+++ b/.github/workflows/ci-ui-package.yml
@@ -15,6 +15,7 @@ jobs:
   check:
     name: Build & Typecheck
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/release-backend.yml
+++ b/.github/workflows/release-backend.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
     release:
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         steps:
             - uses: actions/checkout@v6
               with:

--- a/.github/workflows/release-ui-core.yml
+++ b/.github/workflows/release-ui-core.yml
@@ -27,6 +27,7 @@ jobs:
     # pushイベント、またはマージされたPRの場合のみ実行
     #    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
GitHub Actions の job ハング時に最大6時間課金される事故防止と、Playwright のブラウザDLハング既知バグ対策をまとめて行います。

- `timeout-minutes` 未設定の job に `timeout-minutes: 10` を付与（設定済みは変更なし）
- `@playwright/test` / `playwright` が 1.60.0 未満なら `^1.60.0` へ引き上げ（[microsoft/playwright#40747](https://github.com/microsoft/playwright/pull/40747) で修正済みの Node 24.16+ ハング対策）
- 対象 lockfile を更新

自動生成PR。マージは手動。
