### PR TITLE
fix(deps): Dependabot 脆弱性対応（Critical/High 中心の推移的依存パッチ）

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -28,6 +28,9 @@ repositories {
 // Spring AI BOM for dependency management
 ext {
     springAiVersion = '1.1.6'
+    // セキュリティ修正: Spring Boot 管理下の推移的依存をパッチ版へ上書き（Dependabot 対応）
+    set('tomcat.version', '10.1.55')        // CVE: GHSA-5m62-pw8w-7w9f 他 (Critical)
+    set('netty.version', '4.1.133.Final')   // CVE: GHSA-57rv-r2g8-2cj3 他 (High)
 }
 
 dependencyManagement {
@@ -58,6 +61,9 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.17'
     implementation 'com.h2database:h2:2.4.240'
     runtimeOnly 'org.postgresql:postgresql:42.7.11'
+    // セキュリティ修正: BouncyCastle をパッチ版へ明示固定（GHSA-p93r-85wp-75v3 他, High/Medium）
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.84'
+    implementation 'org.bouncycastle:bcpkix-jdk18on:1.84'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.apache.commons:commons-lang3:3.20.0'
     implementation 'com.google.guava:guava:33.6.0-jre'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion: ^5.0.6
+  ws: ^8.20.1
+
 importers:
 
   .:
@@ -269,7 +273,7 @@ importers:
         version: 8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@uiw/codemirror-theme-vscode':
         specifier: ^4.25.9
-        version: 4.25.9(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.42.1)
+        version: 4.25.9(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1904,8 +1908,8 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   browser-image-compression@2.0.2:
@@ -3254,8 +3258,8 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -4939,11 +4943,25 @@ snapshots:
       - '@codemirror/state'
       - '@codemirror/view'
 
+  '@uiw/codemirror-theme-vscode@4.25.9(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)':
+    dependencies:
+      '@uiw/codemirror-themes': 4.25.9(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)
+    transitivePeerDependencies:
+      - '@codemirror/language'
+      - '@codemirror/state'
+      - '@codemirror/view'
+
   '@uiw/codemirror-themes@4.25.9(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.42.1)':
     dependencies:
       '@codemirror/language': 6.12.3
       '@codemirror/state': 6.6.0
       '@codemirror/view': 6.42.1
+
+  '@uiw/codemirror-themes@4.25.9(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.0)':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.43.0
 
   '@uiw/react-codemirror@4.25.9(@babel/runtime@7.29.2)(@codemirror/autocomplete@6.20.1)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.6)(@codemirror/search@6.5.11)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.42.1)(codemirror@6.0.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
@@ -5094,7 +5112,7 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5505,7 +5523,7 @@ snapshots:
       '@types/ws': 8.18.1
       entities: 7.0.1
       whatwg-mimetype: 3.0.0
-      ws: 8.20.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -5732,7 +5750,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   mlly@1.8.0:
     dependencies:
@@ -6320,7 +6338,7 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,8 @@
 packages:
   - 'apps/*'
   - 'packages/*'
+
+# セキュリティ修正: 推移的依存をパッチ版へ固定（Dependabot 対応 / pnpm 11.5 は overrides を本ファイルで読む）
+overrides:
+  brace-expansion: '^5.0.6'  # GHSA-jxxr-4gwj-5jf2 (Medium)
+  ws: '^8.20.1'              # GHSA-58qx-3vcg-4xpx (Medium)


### PR DESCRIPTION
## 概要

GitHub Dependabot のオープンアラートのうち **Critical / High を中心に**、脆弱性のある推移的依存をパッチ版へ更新しました。

## 変更内容

| 重大度 | パッケージ | 変更 | 方法 |
|---|---|---|---|
| Critical | tomcat-embed-core | 10.1.54 → 10.1.55 | `build.gradle` `tomcat.version` 上書き |
| High | netty-codec(-http/http2/dns 他) | 4.1.132 → 4.1.133.Final | `netty.version` 上書き |
| High/Med | bouncycastle bcprov/bcpkix-jdk18on | 1.83 → 1.84 | 依存を明示固定 |
| Med | brace-expansion | 5.0.5 → 5.0.6 | `pnpm-workspace.yaml` overrides |
| Med | ws | 8.20.0 → 8.21.0 | 同上 |

関連アラート: #220 #218 #215 #217 #216 #214 #204 #201 #205 #207 #208 #196 #194 #195 #212 #213

## なぜ

公開 OSS のためデフォルトブランチに多数の脆弱性アラートが出ており、影響度の高いものから解消するため。

## レビュー時の補足

- **postgresql / commons-lang3** は既にパッチ版へ解決されており、該当アラートは stale。
- **mcp-core (1.0.x) / opentelemetry-api / junrar** は Spring AI BOM 管理下でメジャー/マイナー更新が破壊的変更リスクを伴うため、本 PR ではスコープ外。別途個別対応が必要。
- pnpm 11.5 では `package.json` の `pnpm.overrides` が読まれなくなっている（`undici` 等が無効化済み）。本 PR では最小限で `pnpm-workspace.yaml` 側に追記した。既存 overrides 群の移行は別途要対応。

## 検証

- 依存解決でパッチ版へ上書きされることを `gradlew :backend:dependencies` で確認
- `./gradlew :backend:compileJava` 成功
- `pnpm install --lockfile-only` でロックファイル更新